### PR TITLE
Adding the capability to mark properties as required, and to have them be arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # SwaggerYard #
 
 The SwaggerYard gem is a Rails Engine designed to parse your Yardocs API controller.
-It'll create a Swagger-UI complaint JSON to be served out through where you mount SwaggerYard. 
+It'll create a Swagger-UI complaint JSON to be served out through where you mount SwaggerYard.
 You can mount this to the Rails app serving the REST API or you could mount it as a separate Rails app.
-Parsing of the Yardocs happens during the server startup and the data will be subsequently cached to the Rails cache you have defined. 
+Parsing of the Yardocs happens during the server startup and the data will be subsequently cached to the Rails cache you have defined.
 If your API is large expect a slow server start up time.
 
 ## Installation ##
-  
+
 Put SwaggerYard in your Gemfile:
 
     gem 'swagger_yard'
@@ -20,7 +20,7 @@ Install the gem with Bunder:
 ## Getting Started ##
 
 ### Place your configuration in a your rails initializers ###
-    
+
     # config/initializers/swagger_yard.rb
     SwaggerYard.configure do |config|
       config.swagger_version = "1.2"
@@ -60,10 +60,10 @@ class Accounts::OwnershipsController < ActionController::Base
   # @parameter          [Integer]   offset            Used for pagination of response data (default: 25 items per response). Specifies the offset of the next block of data to receive.
   # @parameter          [Array]     status            Filter by status. (e.g. status[]=1&status[]=2&status[]=3).
   # @parameter_list     [String]    sort_order        Orders response by fields. (e.g. sort_order=created_at).
-  #                     [List]      id                
-  #                     [List]      begin_at          
-  #                     [List]      end_at            
-  #                     [List]      created_at        
+  #                     [List]      id
+  #                     [List]      begin_at
+  #                     [List]      end_at
+  #                     [List]      created_at
   # @parameter          [Boolean]   sort_descending   Reverse order of sort_order sorting, make it descending.
   # @parameter          [Date]      begin_at_greater  Filters response to include only items with begin_at >= specified timestamp (e.g. begin_at_greater=2012-02-15T02:06:56Z).
   # @parameter          [Date]      begin_at_less     Filters response to include only items with begin_at <= specified timestamp (e.g. begin_at_less=2012-02-15T02:06:56Z).
@@ -79,13 +79,14 @@ end
 ### Here is an example of how to use SwaggerYard in your Model ###
 
 ```ruby
-# 
+#
 # @model Pet
-# 
-# @property id    [integer]   the identifier for the pet
-# @property name  [string]    the name of the pet
+#
+# @property id    [integer, required]   the identifier for the pet
+# @property name  [array, string]    the names for the pet
 # @property age   [integer]   the age of the pet
-# 
+# @property relatives [array, Pet, required] other Pets in its family
+#
 class Pet
 end
 ```
@@ -101,9 +102,9 @@ To then use your `Model` in your `Controller` documentation, add `@parameter`s:
 Currently, SwaggerYard only supports API Key auth descriptions. Start by adding `@authorization` to your `ApplicationController`.
 
 ```ruby
-# 
+#
 # @authorization [api_key] header X-APPLICATION-API-KEY
-# 
+#
 class ApplicationController < ActionController::Base
 end
 ```
@@ -133,7 +134,7 @@ There are two generators that you can use, if you need to customize the UI/JS (o
      rails g swagger_yard:ui
      rails g swagger_yard:js
 
-They both copy over their respective files over to your Rails app to be customized. 
+They both copy over their respective files over to your Rails app to be customized.
 See [rails engines overriding views](http://guides.rubyonrails.org/engines.html#overriding-views) for more info
 
 Copying over JS requires that ActionDispatch::Static middleware be used (by default it should in use).
@@ -149,4 +150,3 @@ By default SwaggerYard will use a slightly modify version of the swagger-ui. Cha
 * [Swagger-ui](https://github.com/wordnik/swagger-ui)
 * [Yard](https://github.com/lsegal/yard)
 * [Swagger-spec version 1.2](https://github.com/wordnik/swagger-spec/blob/master/versions/1.2.md)
-

--- a/app/controllers/swagger_yard/swagger_controller.rb
+++ b/app/controllers/swagger_yard/swagger_controller.rb
@@ -11,7 +11,7 @@ module SwaggerYard
     def show
       declaration = resource_listing.declaration_for("/#{params[:resource]}").to_h
 
-      declaration.merge!("basePath" => request.base_url + SwaggerYard.config.api_path) if declaration["basePath"].blank? 
+      declaration.merge!("basePath" => request.base_url + SwaggerYard.config.api_path) if declaration["basePath"].blank?
       render :json => declaration
     end
 

--- a/lib/swagger_yard/api_declaration.rb
+++ b/lib/swagger_yard/api_declaration.rb
@@ -60,7 +60,7 @@ module SwaggerYard
     end
 
     def models
-      model_names = model_names_from_apis
+      model_names = (model_names_from_apis + model_names_from_model_properties).uniq
       @resource_listing.models.select {|m| model_names.include?(m.id)}
     end
 
@@ -69,7 +69,7 @@ module SwaggerYard
     end
 
     def to_h
-      { 
+      {
         "apiVersion"     => SwaggerYard.config.api_version,
         "swaggerVersion" => SwaggerYard.config.swagger_version,
         "basePath"       => SwaggerYard.config.api_base_path,
@@ -90,6 +90,10 @@ module SwaggerYard
     private
     def model_names_from_apis
       apis.values.map(&:model_names).flatten.uniq
+    end
+
+    def model_names_from_model_properties
+      @resource_listing.models.map(&:properties_model_names).flatten.uniq
     end
   end
 end

--- a/lib/swagger_yard/model.rb
+++ b/lib/swagger_yard/model.rb
@@ -1,8 +1,8 @@
 module SwaggerYard
-  # 
+  #
   # Carries id (the class name) and properties for a referenced
   #   complex model object as defined by swagger schema
-  # 
+  #
   class Model
     attr_reader :id
 
@@ -41,35 +41,61 @@ module SwaggerYard
       self
     end
 
+    def properties_model_names
+      @properties.select(&:is_ref?).map(&:type)
+    end
+
     def to_h
       raise "Model is missing @model tag" if id.nil?
 
       {
         "id" => id,
-        "properties" => Hash[@properties.map {|property| [property.name, property.to_h]}]
+        "properties" => Hash[@properties.map {|property| [property.name, property.to_h]}],
+        "required" => @properties.select(&:is_required?).map(&:name)
       }
     end
 
   end
 
-  # 
+  #
   # Holds the name and type for a single model property
-  # 
+  #
   class Property
     attr_reader :name
 
     def self.from_tag(tag)
-      new(tag.name, tag.types.first, tag.text)
+      new(tag.name, tag.types, tag.text)
     end
 
-    def initialize(name, type, description)
-      @name, @type, _ = name, type, description
+    def initialize(name, types, description)
+      @name, @types, @description = name, types, description
+    end
+
+    def type
+      is_array? ? @types[1] : @types[0]
+    end
+
+    def is_array?
+      @types[0] == "array"
+    end
+
+    def is_required?
+      @types.size > 1 && @types.last == "required"
+    end
+
+    def is_ref?
+      /[[:upper:]]/.match(type[0])
     end
 
     def to_h
-      {
-        "type" => @type
-      }
+      type_tag = is_ref? ? "$ref" : "type"
+      result = if is_array?
+        { "type" => "array", "items" => { type_tag => type } }
+      else
+        { type_tag => @types.first }
+      end
+      result["description"] = @description if @description
+      result
     end
   end
 end

--- a/lib/swagger_yard/resource_listing.rb
+++ b/lib/swagger_yard/resource_listing.rb
@@ -24,7 +24,7 @@ module SwaggerYard
     end
 
     def to_h
-      { 
+      {
         "apiVersion"      => SwaggerYard.config.api_version,
         "swaggerVersion"  => SwaggerYard.config.swagger_version,
         "basePath"        => SwaggerYard.config.swagger_spec_base_path,

--- a/spec/fixtures/dummy/app/models/animal_thing.rb
+++ b/spec/fixtures/dummy/app/models/animal_thing.rb
@@ -1,0 +1,8 @@
+#
+# @model AnimalThing
+#
+# @property id    [integer, required]   the identifier for the animal thing
+# @property type  [string]    the type of animal
+#
+class AnimalThing
+end

--- a/spec/fixtures/dummy/app/models/pet.rb
+++ b/spec/fixtures/dummy/app/models/pet.rb
@@ -1,9 +1,10 @@
-# 
+#
 # @model Pet
-# 
-# @property id    [integer]   the identifier for the pet
-# @property name  [string]    the name of the pet
+#
+# @property id    [integer, required]   the identifier for the pet
+# @property name  [array, string]    the names for the pet
 # @property age   [integer]   the age of the pet
-# 
+# @property relatives [array, AnimalThing, required] other Pets in its family
+#
 class Pet
 end

--- a/spec/fixtures/pets.json
+++ b/spec/fixtures/pets.json
@@ -135,13 +135,31 @@
     }
   ],
   "models":{
+    "AnimalThing":{
+      "id":"AnimalThing",
+      "properties": {
+        "id":{"type":"integer", "description":"the identifier for the animal thing"},
+        "type":{"type":"string", "description":"the type of animal"}
+      },
+      "required":["id"]
+    },
     "Pet":{
       "id":"Pet",
       "properties":{
-        "id":{"type":"integer"},
-        "name":{"type":"string"},
-        "age":{"type":"integer"}
-      }
+        "id":{"type":"integer","description":"the identifier for the pet"},
+        "name":{
+          "type":"array",
+          "items": {"type":"string"},
+          "description":"the names for the pet"
+        },
+        "age":{"type":"integer","description":"the age of the pet"},
+        "relatives": {
+          "type":"array",
+          "items":{"$ref":"AnimalThing"},
+          "description":"other Pets in its family"
+        }
+      },
+      "required":["id","relatives"]
     }
   },
   "authorizations":{

--- a/spec/integration/swagger_yard_spec.rb
+++ b/spec/integration/swagger_yard_spec.rb
@@ -4,7 +4,7 @@ describe SwaggerYard, '.generate' do
   let(:app_path) {'../../fixtures/dummy/app/'}
 
   context "for a valid controller" do
-    let(:model_path) {File.expand_path(app_path+'models/pet.rb', __FILE__)}
+    let(:model_path) {File.expand_path(app_path+'models/*.rb', __FILE__)}
     let(:controller_path) {File.expand_path(app_path+'controllers/*.rb', __FILE__)}
 
     let(:resource_listing) {SwaggerYard::ResourceListing.new(controller_path, model_path)}


### PR DESCRIPTION
Model Properties can now be:
- required
- carrying a description
- arrays (both of basic types, and of `$refs` / other Models

See the following screenshot with how the new sections look in the Swagger UI:

![](http://content.screencast.com/users/tim.schmelmer/folders/Jing/media/8bf0488d-5731-451b-b7ed-c14b9f8a0562/00000255.png)
