### PR TITLE
Adding the ability to return arrays from operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ class Accounts::OwnershipsController < ActionController::Base
   # @parameter          [Date]      end_at_greater    Filters response to include only items with end_at >= specified timestamp (e.g. end_at_greater=2012-02-15T02:06:56Z).
   # @parameter          [Date]      end_at_less       Filters response to include only items with end_at <= specified timestamp (e.g. end_at_less=2012-02-15T02:06:56Z).
   #
+  # @response_type [array, Pet]
   def index
     ...
   end

--- a/lib/swagger_yard.rb
+++ b/lib/swagger_yard.rb
@@ -4,6 +4,7 @@ require "swagger_yard/configuration"
 require "swagger_yard/parameter"
 require "swagger_yard/property"
 require "swagger_yard/operation"
+require "swagger_yard/response_type"
 require "swagger_yard/authorization"
 require "swagger_yard/resource_listing"
 require "swagger_yard/api_declaration"
@@ -34,10 +35,10 @@ module SwaggerYard
 
     #
     # Use YARD to parse object tags from a file
-    # 
+    #
     # @param file_path [string] The complete path to file
     # @return [YARD] objects representing class/methods and tags from the file
-    # 
+    #
     def yard_objects_from_file(file_path)
       ::YARD::Registry.clear
       ::YARD.parse(file_path)
@@ -58,7 +59,7 @@ module SwaggerYard
       ::YARD::Tags::Library.define_tag("Parameter list", :parameter_list)
       ::YARD::Tags::Library.define_tag("Status code", :status_code)
       ::YARD::Tags::Library.define_tag("Implementation notes", :notes)
-      ::YARD::Tags::Library.define_tag("Response type", :response_type)
+      ::YARD::Tags::Library.define_tag("Response type", :response_type, :with_types)
       ::YARD::Tags::Library.define_tag("Error response message", :error_message, :with_types_and_name)
       ::YARD::Tags::Library.define_tag("Api Summary", :summary)
       ::YARD::Tags::Library.define_tag("Model resource", :model)

--- a/lib/swagger_yard/operation.rb
+++ b/lib/swagger_yard/operation.rb
@@ -18,7 +18,7 @@ module SwaggerYard
           when "parameter_list"
             operation.add_parameter_list(tag)
           when "response_type"
-            operation.response_type = tag.text
+            operation.response_type = ResponseType.from_tag(tag)
           when "error_message"
             operation.add_error_message(tag)
           when "summary"
@@ -45,16 +45,21 @@ module SwaggerYard
     end
 
     def to_h
-      {
+      res = {
         "httpMethod"        => http_method,
         "nickname"          => nickname,
-        "type"              => response_type || "void",
+        "type"              => "void",
+        "items"             => nil,
         "produces"          => ["application/json", "application/xml"],
         "parameters"        => parameters.map(&:to_h),
         "summary"           => summary || @api.description,
         "notes"             => notes,
         "responseMessages"  => error_messages
       }
+
+      res.merge!(response_type.to_h) if response_type
+      res.reject! {|k,v| k == 'items' && v == nil}
+      res
     end
 
     ##
@@ -80,10 +85,10 @@ module SwaggerYard
 
     ##
     # Example: [String]    sort_order  Orders ownerships by fields. (e.g. sort_order=created_at)
-    #          [List]      id              
-    #          [List]      begin_at        
-    #          [List]      end_at          
-    #          [List]      created_at      
+    #          [List]      id
+    #          [List]      begin_at
+    #          [List]      end_at
+    #          [List]      created_at
     def add_parameter_list(tag)
       # TODO: switch to using Parameter.from_yard_tag
       data_type, name, required, description, list_string = parse_parameter_list(tag)

--- a/lib/swagger_yard/response_type.rb
+++ b/lib/swagger_yard/response_type.rb
@@ -1,0 +1,37 @@
+module SwaggerYard
+  #
+  # Holds the name and type for a single model property
+  #
+  class ResponseType
+    attr_reader :name
+
+    def self.from_tag(tag)
+      new(tag.types, tag.text)
+    end
+
+    def initialize(types, description)
+      @types, @description = types, description
+    end
+
+    def type
+      is_array? ? @types[1] : @types[0]
+    end
+
+    def is_array?
+      @types[0] == "array"
+    end
+
+    def is_ref?
+      /[[:upper:]]/.match(type[0])
+    end
+
+    def to_h
+      type_tag = is_ref? ? "$ref" : "type"
+      result = if is_array?
+        { "type" => "array", "items" => { type_tag => type } }
+      else
+        { "type" => type }
+      end
+    end
+  end
+end

--- a/spec/fixtures/dummy/app/controllers/pets_controller.rb
+++ b/spec/fixtures/dummy/app/controllers/pets_controller.rb
@@ -1,13 +1,14 @@
 # @resource Pet
 # @resource_path /pets
-# 
+#
 # This document describes the API for interacting with Pet resources
-# 
+#
 # @authorize_with header_x_application_api_key
-# 
+#
 class PetsController < ApplicationController
   # return a list of Pets
   # @path [GET] /pets.{format_type}
+  # @response_type [array, Pet]
   # @parameter [string] client_name(required) The name of the client using the API
   def index
   end
@@ -15,7 +16,7 @@ class PetsController < ApplicationController
   # return a Pet
   # @path [GET] /pets/{id}.{format_type}
   # @parameter [integer] id The ID for the Pet
-  # @response_type Pet
+  # @response_type [Pet]
   # @error_message [EmptyPet] 404 Pet not found
   # @error_message 400 Invalid ID supplied
   def show

--- a/spec/fixtures/pets.json
+++ b/spec/fixtures/pets.json
@@ -11,7 +11,8 @@
         {
           "httpMethod":"GET",
           "nickname":"pets-format-type-get",
-          "type":"void",
+          "type":"array",
+          "items":{"$ref":"Pet"},
           "produces":["application/json", "application/xml"],
           "parameters":[
             {


### PR DESCRIPTION
Response types can now be specified to be arrays of data types, see:

![](http://content.screencast.com/users/tim.schmelmer/folders/Jing/media/a6814a69-868c-4614-b6e0-5973bb50fc0d/00000260.png)
