### PR TITLE
Improve Type Parsing

### DIFF
--- a/lib/swagger_yard/type.rb
+++ b/lib/swagger_yard/type.rb
@@ -7,7 +7,7 @@ module SwaggerYard
       if parts.size > 1
         case parts.first
         when /^array$/i
-          options[:array] = true
+          options[:array] = parts[1..-1]
         when /^enum$/i
           name = nil
           options[:enum] = parts.last.split(/[,|]/)
@@ -75,7 +75,7 @@ module SwaggerYard
       end
 
       if array?
-        { "type" => "array", "items" => type }
+        { "type" => "array", "items" => Type.from_type_list([array.join("<")]).to_h }
       elsif object?
         {
           "type" => "object",

--- a/spec/lib/swagger_yard/type_spec.rb
+++ b/spec/lib/swagger_yard/type_spec.rb
@@ -71,5 +71,18 @@ RSpec.describe SwaggerYard::Type do
         }
       })
     end
+
+    it 'handles object definitions with both properties and additionalProperties' do
+      expect(type('object<foo: string,bar: integer<int32>,string>').to_h).to eq({
+        "type" => "object",
+        "properties" => {
+          "foo" => { "type" => "string" },
+          "bar" => { "type" => "integer", "format" => "int32" }
+        },
+        "additionalProperties" => {
+          "type" => "string"
+        }
+      })
+    end
   end
 end

--- a/spec/lib/swagger_yard/type_spec.rb
+++ b/spec/lib/swagger_yard/type_spec.rb
@@ -59,5 +59,17 @@ RSpec.describe SwaggerYard::Type do
         }
       })
     end
+
+    it 'handles object definitions nested in an array' do
+      expect(type('array<object<string>>').to_h).to eq({
+        "type" => "array",
+        "items" => {
+          "type" => "object",
+          "additionalProperties" => {
+            "type" => "string"
+          }
+        }
+      })
+    end
   end
 end


### PR DESCRIPTION
I'm trying to improve Type parsing in the following ways:
- Allow for nesting the object type in the array type (first commit)
- Allow for specifying object properties and their types (second commit)