### PR TITLE
Sort resource tag array by name

### DIFF
--- a/lib/swagger_yard/resource_listing.rb
+++ b/lib/swagger_yard/resource_listing.rb
@@ -35,7 +35,7 @@ module SwaggerYard
 
     # Resources
     def tag_objects
-      controllers.map(&:to_tag)
+      controllers.sort {|a,b| a.resource.upcase <=> b.resource.upcase}.map(&:to_tag)
     end
 
     def model_objects


### PR DESCRIPTION
A lot of display tools such as Swagger UI use the order of the tags as the order to list the resource endpoints. When this list is long, it's easier to scroll through and find what you're looking for if the list is in alphabetical order.