### PR TITLE
Validation fixes

### DIFF
--- a/lib/swagger_yard.rb
+++ b/lib/swagger_yard.rb
@@ -33,6 +33,10 @@ module SwaggerYard
       @configuration ||= Configuration.new
     end
 
+    def log
+      YARD::Logger.instance
+    end
+
     #
     # Use YARD to parse object tags from a file
     #

--- a/lib/swagger_yard/api.rb
+++ b/lib/swagger_yard/api.rb
@@ -11,7 +11,7 @@ module SwaggerYard
           yard_object.add_tag YARD::Tags::Tag.new("path", path, [method]) if path
           path
         rescue => e
-          YARD::Logger.instance.warn e.message
+          SwaggerYard.log.warn e.message
           nil
         end
       end

--- a/lib/swagger_yard/api_declaration.rb
+++ b/lib/swagger_yard/api_declaration.rb
@@ -41,7 +41,7 @@ module SwaggerYard
       end
 
       if tag = yard_object.tags.detect {|t| t.tag_name == "resource_path"}
-        log.warn "DEPRECATED: @resource_path tag is obsolete."
+        SwaggerYard.log.warn "DEPRECATED: @resource_path tag is obsolete."
       end
 
       # we only have api_key auth, the value for now is always empty array

--- a/lib/swagger_yard/operation.rb
+++ b/lib/swagger_yard/operation.rb
@@ -91,7 +91,7 @@ module SwaggerYard
     # Example: [PUT] /api/v1/accounts/{account_id}
     def add_path_params_and_method(tag)
       if @path && @http_method
-        YARD::Logger.instance.warn 'multiple path tags not supported: ' \
+        SwaggerYard.log.warn 'multiple path tags not supported: ' \
           "ignored [#{tag.types.first}] #{tag.text}"
         return
       end
@@ -120,7 +120,7 @@ module SwaggerYard
         existing.required     ||= parameter.required
         existing.allow_multiple = parameter.allow_multiple
       elsif parameter.param_type == 'body' && @parameters.detect {|param| param.param_type == 'body'}
-        YARD::Logger.instance.warn 'multiple body parameters invalid: ' \
+        SwaggerYard.log.warn 'multiple body parameters invalid: ' \
           "ignored #{parameter.name} for #{@api.api_declaration.class_name}##{ruby_method}"
       else
         @parameters << parameter

--- a/lib/swagger_yard/operation.rb
+++ b/lib/swagger_yard/operation.rb
@@ -90,6 +90,12 @@ module SwaggerYard
     # Example: [GET] /api/v2/ownerships
     # Example: [PUT] /api/v1/accounts/{account_id}
     def add_path_params_and_method(tag)
+      if @path && @http_method
+        YARD::Logger.instance.warn 'multiple path tags not supported: ' \
+          "ignored [#{tag.types.first}] #{tag.text}"
+        return
+      end
+
       @path = tag.text
       @http_method = tag.types.first
 

--- a/lib/swagger_yard/operation.rb
+++ b/lib/swagger_yard/operation.rb
@@ -113,6 +113,9 @@ module SwaggerYard
         existing.param_type     = parameter.param_type if parameter.from_path?
         existing.required     ||= parameter.required
         existing.allow_multiple = parameter.allow_multiple
+      elsif parameter.param_type == 'body' && @parameters.detect {|param| param.param_type == 'body'}
+        YARD::Logger.instance.warn 'multiple body parameters invalid: ' \
+          "ignored #{parameter.name} for #{@api.api_declaration.class_name}##{ruby_method}"
       else
         @parameters << parameter
       end

--- a/lib/swagger_yard/parameter.rb
+++ b/lib/swagger_yard/parameter.rb
@@ -1,6 +1,6 @@
 module SwaggerYard
   class Parameter
-    attr_accessor :name, :description, :param_type, :required, :allow_multiple
+    attr_accessor :name, :type, :description, :param_type, :required, :allow_multiple
 
     def self.from_yard_tag(tag, operation)
       name, options_string = tag.name.split(/[\(\)]/)

--- a/lib/swagger_yard/parameter.rb
+++ b/lib/swagger_yard/parameter.rb
@@ -3,8 +3,9 @@ module SwaggerYard
     attr_accessor :name, :description, :param_type, :required, :allow_multiple
 
     def self.from_yard_tag(tag, operation)
-      description = tag.text
       name, options_string = tag.name.split(/[\(\)]/)
+      description = tag.text
+      description = name if description.strip.empty?
       type = Type.from_type_list(tag.types)
 
       options = {}

--- a/lib/swagger_yard/property.rb
+++ b/lib/swagger_yard/property.rb
@@ -26,11 +26,13 @@ module SwaggerYard
 
     def to_h
       @type.to_h.tap do |h|
-        h["description"] = description if description
-        if @nullable
-          h["x-nullable"] = true
-          if h["type"]
-            h["type"] = [h["type"], "null"]
+        unless h['$ref']
+          h["description"] = description if description
+          if @nullable
+            h["x-nullable"] = true
+            if h["type"]
+              h["type"] = [h["type"], "null"]
+            end
           end
         end
       end

--- a/lib/swagger_yard/resource_listing.rb
+++ b/lib/swagger_yard/resource_listing.rb
@@ -30,7 +30,9 @@ module SwaggerYard
     end
 
     def path_objects
-      controllers.map(&:apis_hash).reduce({}, :merge)
+      controllers.map(&:apis_hash).reduce({}, :merge).tap do |paths|
+        warn_duplicate_operations(paths)
+      end
     end
 
     # Resources
@@ -72,6 +74,19 @@ module SwaggerYard
           end
         end
       end.flatten.select(&:valid?)
+    end
+
+    def warn_duplicate_operations(paths)
+      operation_ids = []
+      paths.each do |path,ops|
+        ops.each do |method,op|
+          if operation_ids.include?(op['operationId'])
+            log.warn("duplicate operation #{op['operationId']}")
+            next
+          end
+          operation_ids << op['operationId']
+        end
+      end
     end
   end
 end

--- a/lib/swagger_yard/resource_listing.rb
+++ b/lib/swagger_yard/resource_listing.rb
@@ -81,7 +81,7 @@ module SwaggerYard
       paths.each do |path,ops|
         ops.each do |method,op|
           if operation_ids.include?(op['operationId'])
-            log.warn("duplicate operation #{op['operationId']}")
+            SwaggerYard.log.warn("duplicate operation #{op['operationId']}")
             next
           end
           operation_ids << op['operationId']

--- a/spec/lib/swagger_yard/operation_spec.rb
+++ b/spec/lib/swagger_yard/operation_spec.rb
@@ -79,6 +79,11 @@ RSpec.describe SwaggerYard::Operation do
     its("parameters.count") { is_expected.to eq(1) }
     its("parameters.last.name") { is_expected.to eq("body") }
     its("parameters.last.type.name") { is_expected.to eq("object") }
+
+    it "warns about multiple body parameters" do
+      stub_logger.expects(:warn).at_least_once
+      subject
+    end
   end
 
   context "with multiple path tags, ignores all but the first path" do
@@ -87,5 +92,10 @@ RSpec.describe SwaggerYard::Operation do
                   yard_tag("@path [POST] /hello2")] }
     its("path") { is_expected.to eq('/hello') }
     its("http_method") { is_expected.to eq('GET') }
+
+    it "warns about multiple path tags" do
+      stub_logger.expects(:warn).at_least_once
+      subject
+    end
   end
 end

--- a/spec/lib/swagger_yard/operation_spec.rb
+++ b/spec/lib/swagger_yard/operation_spec.rb
@@ -59,4 +59,12 @@ RSpec.describe SwaggerYard::Operation do
     its(['x-controller']) { is_expected.to eq('my/hello') }
     its(['x-action'])     { is_expected.to eq('hello') }
   end
+
+  context "with a declared parameter that has no description" do
+    let(:tags) { [yard_tag("@path [GET] /hello/{message}"),
+                  yard_tag("@parameter name [string]")] }
+
+    its("parameters.last.name") { is_expected.to eq("name") }
+    its("parameters.last.description") { is_expected.to eq("name") }
+  end
 end

--- a/spec/lib/swagger_yard/operation_spec.rb
+++ b/spec/lib/swagger_yard/operation_spec.rb
@@ -61,10 +61,23 @@ RSpec.describe SwaggerYard::Operation do
   end
 
   context "with a declared parameter that has no description" do
-    let(:tags) { [yard_tag("@path [GET] /hello/{message}"),
+    let(:tags) { [yard_tag("@path [GET] /hello"),
                   yard_tag("@parameter name [string]")] }
 
+    its("parameters.count") { is_expected.to eq(1) }
     its("parameters.last.name") { is_expected.to eq("name") }
     its("parameters.last.description") { is_expected.to eq("name") }
+  end
+
+  context "with multiple body parameters, ignores all but the first one" do
+    include SilenceLogger
+
+    let(:tags) { [yard_tag("@path [GET] /hello"),
+                  yard_tag("@parameter body(body) [object]"),
+                  yard_tag("@parameter name(body) [string]")] }
+
+    its("parameters.count") { is_expected.to eq(1) }
+    its("parameters.last.name") { is_expected.to eq("body") }
+    its("parameters.last.type.name") { is_expected.to eq("object") }
   end
 end

--- a/spec/lib/swagger_yard/operation_spec.rb
+++ b/spec/lib/swagger_yard/operation_spec.rb
@@ -80,4 +80,12 @@ RSpec.describe SwaggerYard::Operation do
     its("parameters.last.name") { is_expected.to eq("body") }
     its("parameters.last.type.name") { is_expected.to eq("object") }
   end
+
+  context "with multiple path tags, ignores all but the first path" do
+    include SilenceLogger
+    let(:tags) { [yard_tag("@path [GET] /hello"),
+                  yard_tag("@path [POST] /hello2")] }
+    its("path") { is_expected.to eq('/hello') }
+    its("http_method") { is_expected.to eq('GET') }
+  end
 end

--- a/spec/lib/swagger_yard/property_spec.rb
+++ b/spec/lib/swagger_yard/property_spec.rb
@@ -49,7 +49,7 @@ describe SwaggerYard::Property do
   context "with a model type" do
     let(:tag) { yard_tag '@property name [Name]   Name' }
 
-    its(['$ref'])   { is_expected.to eq('#/definitions/Name') }
+    it { is_expected.to eq('$ref' => '#/definitions/Name') }
   end
 
   context "with an array of models" do
@@ -83,8 +83,7 @@ describe SwaggerYard::Property do
   context "with a nullable model" do
     let(:tag) { yard_tag '@property name(nullable) [Name]  Name' }
 
-    its(['$ref'])           { is_expected.to eq('#/definitions/Name') }
-    its(['x-nullable'])     { is_expected.to eq(true) }
+    it { is_expected.to eq('$ref' => '#/definitions/Name') }
   end
 
 end

--- a/spec/lib/swagger_yard/resource_listing_spec.rb
+++ b/spec/lib/swagger_yard/resource_listing_spec.rb
@@ -78,4 +78,21 @@ RSpec.describe SwaggerYard::ResourceListing, "reparsing" do
       expect(multi_resource_listing.security_objects).to include(security_definitions)
     end
   end
+
+  context '#path_objects' do
+    include SilenceLogger
+
+    it 'warns about duplicate operations' do
+      stub_logger.expects(:warn).once
+
+      api_decl = SwaggerYard::ApiDeclaration.new
+      api_decl.resource = 'system'
+      api_decl.add_yard_object(yard_method(:index, '@path [GET] /accounts'))
+      api_decl.add_yard_object(yard_method(:index, '@path [GET] /people'))
+
+      listing = resource_listing
+      listing.instance_variable_set(:@controllers, [api_decl])
+      listing.path_objects
+    end
+  end
 end

--- a/spec/support/parslet.rb
+++ b/spec/support/parslet.rb
@@ -1,6 +1,6 @@
 # Patch ParseFailed to be better behaved for RSpec
 class Parslet::ParseFailed
-  remove_method :cause
+  remove_method :cause if instance_methods(false).include?(:cause)
 end
 
 RSpec::Matchers.define :parse do |str,*rest|

--- a/spec/support/silence_logger.rb
+++ b/spec/support/silence_logger.rb
@@ -1,8 +1,9 @@
 module SilenceLogger
   def self.included(base)
+    base.let(:stub_logger) { stub_everything }
+
     base.before do
       @logger = YARD::Logger.instance
-      stub_logger = stub_everything
       stub_logger.stubs(:enter_level).yields
       stub_logger.stubs(:capture).yields
       YARD::Logger.send :instance_variable_set, :@logger, stub_logger

--- a/spec/support/yard_helpers.rb
+++ b/spec/support/yard_helpers.rb
@@ -4,4 +4,10 @@ module YARDHelpers
     parser.parse content
     parser.tags.first
   end
+
+  def yard_method(name, content)
+    method = YARD::CodeObjects::MethodObject.new(nil, name)
+    method.docstring = YARD::Docstring.new(content, method)
+    method
+  end
 end

--- a/swagger_yard.gemspec
+++ b/swagger_yard.gemspec
@@ -20,10 +20,14 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'yard'
   s.add_runtime_dependency 'parslet'
 
-  s.add_development_dependency 'rake'
+  # TODO: drop the constraint when we drop 1.9 support
+  s.add_development_dependency 'rake', '< 12'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rspec-its'
-  s.add_development_dependency 'apivore'
+  # TODO: drop the constraint when we drop 1.9 support
+  s.add_development_dependency 'apivore', '< 1.6'
+  # TODO: drop explicit nokogiri dependency when we drop 1.9 support
+  s.add_development_dependency 'nokogiri', '< 1.8'
   # TODO: Drop this dependency when we drop 1.9 support
   s.add_development_dependency 'addressable', "<= 2.4.0"
   s.add_development_dependency 'simplecov'


### PR DESCRIPTION
Adds some fixes to help prevent some common swagger validation warnings:

- Warns when the generated swagger document contains duplicate operations
- Warns and ignores more than one `@path` tag per method
- Warns and ignores more than one `@parameter foo(body)` body parameter per method
- Ensure parameter has a description (default to the parameter name)
- Don't add sibling keys to a `{ "$ref": "#/definitions/Foo" }`. Swagger warns that this is not allowed.