### PR TITLE
Refer to external schema for type definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,31 @@ are indicated inside square-brackets (e.g., `[string]`) as part of a YARD tag.
   `[regex<PATTERN>]`. For example, `[regex<^.{3}$>]` produces JSON
   `{ "type": "string", "pattern": "^.{3}$" }`.
 
+### External Schema ###
+
+Types can be specified that refer to external JSON schema documents for their definition. External schema documents are expected to also define their models under a `definitions` top-level key like so:
+```
+{
+  "definitions": {
+    "MyStandardModel": {
+	}
+  }
+}
+```
+
+To register an external schema so that it can be referenced in places where you specify a type, configure SwaggerYard as follows:
+```ruby
+SwaggerYard.configure do |config|
+  config.external_schema mymodels: 'https://example.com/mymodels/v1.0'
+end
+```
+
+Then refer to models in the schema using the syntax `[mymodels#MyStandardModel]` where types are specified. This causes SwaggerYard to emit the following schema for the type:
+
+```
+{ "$ref": "https://example.com/mymodels/v1.0#/definitions/MyStandardModel" }
+```
+
 ### Options ###
 
 Parameter or property _options_ are expressed inside parenthesis immediately

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Types can be specified that refer to external JSON schema documents for their de
 {
   "definitions": {
     "MyStandardModel": {
-	}
+    }
   }
 }
 ```

--- a/lib/swagger_yard.rb
+++ b/lib/swagger_yard.rb
@@ -14,6 +14,10 @@ require "swagger_yard/api"
 require "swagger_yard/swagger"
 
 module SwaggerYard
+  class Error < StandardError; end
+  class InvalidTypeError < Error; end
+  class UndefinedSchemaError < Error; end
+
   class << self
     ##
     # Configuration for Swagger Yard, use like:

--- a/lib/swagger_yard/configuration.rb
+++ b/lib/swagger_yard/configuration.rb
@@ -9,13 +9,21 @@ module SwaggerYard
     attr_accessor :security_definitions
 
     def initialize
-      self.swagger_version = "2.0"
-      self.api_version = "0.1"
-      self.enable = false
-      self.reload = true
-      self.title = "Configure title with SwaggerYard.config.title"
-      self.description = "Configure description with SwaggerYard.config.description"
-      self.security_definitions = {}
+      @swagger_version = "2.0"
+      @api_version = "0.1"
+      @enable = false
+      @reload = true
+      @title = "Configure title with SwaggerYard.config.title"
+      @description = "Configure description with SwaggerYard.config.description"
+      @security_definitions = {}
+      @external_schema = {}
+    end
+
+    def external_schema(mappings = nil)
+      mappings.each do |prefix, url|
+        @external_schema[prefix.to_s] = url
+      end if mappings
+      @external_schema
     end
 
     def swagger_spec_base_path=(ignored)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'simplecov'
 SimpleCov.start do
   add_filter '/spec/'
+  add_filter '/.bundle/'
 end
 
 ENV["RAILS_ENV"] = "development"


### PR DESCRIPTION
Adds a shorthand syntax `prefix#Model` for registering external schema documents by URL that can be used in a swagger document.