### PR TITLE
Model improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ end
 
 ```ruby
 #
-# @model Pet
+# @model
 #
 # @property id(required)    [integer]   the identifier for the pet
 # @property name  [Array<string>]    the names for the pet
@@ -160,7 +160,7 @@ To support Swagger Polymorphism, use `@discriminator` and `@inherits`:
 
 ```ruby
 #
-# @model Pet
+# @model
 #
 # @property id(required)    [integer]   the identifier for the pet
 # @property name  [Array<string>]    the names for the pet
@@ -172,13 +172,23 @@ class Pet
 end
 
 #
-# @model Dog
+# @model
 #
 # @inherits Pet
 #
 # @property packSize(required) [integer] the size of the pack the dog is from
 #
 class Dog < Pet
+end
+```
+
+If you wish to name your model differently from the underlying ruby class, add the name as text to the `@model` tag. In the example here, if we did not specify `Dog` as the model name, it would have been named `Models_Dog`.
+
+```ruby
+# @model Dog
+module Models
+  class Dog
+  end
 end
 ```
 

--- a/lib/swagger_yard/model.rb
+++ b/lib/swagger_yard/model.rb
@@ -4,10 +4,11 @@ module SwaggerYard
   #   complex model object as defined by swagger schema
   #
   class Model
-    attr_reader :id, :discriminator, :inherits
+    attr_reader :id, :discriminator, :inherits, :description
 
     def self.from_yard_object(yard_object)
       new.tap do |model|
+        model.add_info(yard_object)
         model.parse_tags(yard_object.tags)
       end
     end
@@ -23,6 +24,10 @@ module SwaggerYard
 
     def valid?
       !id.nil?
+    end
+
+    def add_info(yard_object)
+      @description = yard_object.docstring
     end
 
     def parse_tags(tags)
@@ -61,7 +66,7 @@ module SwaggerYard
       h = { "allOf" => inherits_references + [h] } unless @inherits.empty?
 
       # Description
-      h["description"] = @description if @description
+      h["description"] = @description unless @description.empty?
 
       h
     end

--- a/lib/swagger_yard/model.rb
+++ b/lib/swagger_yard/model.rb
@@ -28,13 +28,14 @@ module SwaggerYard
 
     def add_info(yard_object)
       @description = yard_object.docstring
+      @id = Model.mangle(yard_object.path)
     end
 
     def parse_tags(tags)
       tags.each do |tag|
         case tag.tag_name
         when "model"
-          @id = Model.mangle(tag.text)
+          @id = Model.mangle(tag.text) unless tag.text.empty?
         when "property"
           @properties << Property.from_tag(tag)
         when "discriminator"

--- a/lib/swagger_yard/model.rb
+++ b/lib/swagger_yard/model.rb
@@ -37,7 +37,7 @@ module SwaggerYard
           @properties << prop
           @discriminator ||= prop.name
         when "inherits"
-          @inherits << Model.mangle(tag.text)
+          @inherits << tag.text
         end
       end
 
@@ -45,11 +45,7 @@ module SwaggerYard
     end
 
     def inherits_references
-      @inherits.map do |name|
-        {
-          "$ref" => "#/definitions/#{name}"
-        }
-      end
+      @inherits.map { |name| Type.new(name).to_h }
     end
 
     def to_h

--- a/spec/fixtures/dummy/app/models/animal_thing.rb
+++ b/spec/fixtures/dummy/app/models/animal_thing.rb
@@ -1,5 +1,5 @@
 #
-# @model AnimalThing
+# @model
 #
 # @property id(required)    [integer]            the identifier for the animal thing
 # @property type            [string]             the type of animal

--- a/spec/fixtures/dummy/app/models/pet.rb
+++ b/spec/fixtures/dummy/app/models/pet.rb
@@ -1,5 +1,7 @@
 #
-# @model Pet
+# This is the Pet model.
+#
+# @model
 #
 # @property id(required)        [integer]             the identifier for the pet
 # @property names               [Array<string>]       the names for the pet

--- a/spec/fixtures/dummy/app/models/pet.rb
+++ b/spec/fixtures/dummy/app/models/pet.rb
@@ -11,3 +11,12 @@
 #
 class Pet
 end
+
+
+module Pets
+  # A dog model.
+  # @model
+  # @inherits Pet
+  class Dog
+  end
+end

--- a/spec/fixtures/dummy/app/models/possession.rb
+++ b/spec/fixtures/dummy/app/models/possession.rb
@@ -1,5 +1,5 @@
 #
-# @model Possession
+# @model
 #
 # @property name  [string]   the name of the possession
 # @property value [float]    the value of the possession

--- a/spec/lib/swagger_yard/model_spec.rb
+++ b/spec/lib/swagger_yard/model_spec.rb
@@ -1,26 +1,25 @@
 require 'spec_helper'
 
 RSpec.describe SwaggerYard::Model do
-  let(:tags) do
-    [
-      yard_tag("@model MyModel"),
-      yard_tag("@discriminator myType(required) [string]")
-    ]
+  let(:content) do
+    [ "@model MyModel",
+      "@discriminator myType(required) [string]" ].join("\n")
   end
 
-  let(:object)    { stub(tags: tags) }
+  let(:object)    { yard_class('MyModel', content) }
+
   subject(:model) { described_class.from_yard_object(object) }
 
   its(:id) { is_expected.to eq("MyModel") }
 
   context "with characters that are not components of a word" do
-    let(:tags) { [yard_tag("@model MyApp::Models::Foo")] }
+    let(:content) { "@model MyApp::Models::Foo" }
 
     its(:id) { is_expected.to eq("MyApp_Models_Foo") }
   end
 
   context "with numeric or _ characters" do
-    let(:tags) { [yard_tag("@model My__Model01")] }
+    let(:content) { "@model My__Model01" }
 
     its(:id) { is_expected.to eq("My__Model01") }
   end
@@ -30,12 +29,12 @@ RSpec.describe SwaggerYard::Model do
   end
 
   context "inherited class with polymorphism" do
-    let(:tags) do
+    let(:content) do
       [
-        yard_tag("@model MyBiggerModel"),
-        yard_tag("@inherits MyModel"),
-        yard_tag("@property myOtherProperty [string]")
-      ]
+        "@model MyBiggerModel",
+        "@inherits MyModel",
+        "@property myOtherProperty [string]"
+      ].join("\n")
     end
 
     its(:to_h) do
@@ -58,8 +57,10 @@ RSpec.describe SwaggerYard::Model do
     end
 
     context 'and an external schema' do
-      let(:tags) { [yard_tag("@model MyModel"),
-                    yard_tag("@inherits schema#OtherModel")] }
+      let(:content) do
+        ["@model MyModel",
+         "@inherits schema#OtherModel"].join("\n")
+      end
       let(:url)  { 'http://example.com/schemas/v1.0' }
       before do
         SwaggerYard.configure do |config|

--- a/spec/lib/swagger_yard/model_spec.rb
+++ b/spec/lib/swagger_yard/model_spec.rb
@@ -28,6 +28,17 @@ RSpec.describe SwaggerYard::Model do
     its(:discriminator) { is_expected.to eq("myType") }
   end
 
+  context "with a description" do
+    let(:desc) {"This is my class. Not your class."}
+    let(:content) do
+      [desc, "", "@model MyModel"].join("\n")
+    end
+    its(:description) { is_expected.to eq(desc) }
+    its(:to_h) do
+      is_expected.to eq({ "type" => "object", "properties" => {}, "description" => desc })
+    end
+  end
+
   context "inherited class with polymorphism" do
     let(:content) do
       [
@@ -58,7 +69,9 @@ RSpec.describe SwaggerYard::Model do
 
     context 'and an external schema' do
       let(:content) do
-        ["@model MyModel",
+        ["The description.",
+         "",
+         "@model MyModel",
          "@inherits schema#OtherModel"].join("\n")
       end
       let(:url)  { 'http://example.com/schemas/v1.0' }
@@ -71,7 +84,8 @@ RSpec.describe SwaggerYard::Model do
       its(:to_h) do
         schema = {
           "allOf" => [{ "$ref" => "#{url}#/definitions/OtherModel" },
-                      { "type" => "object", "properties" => {} }]
+                      { "type" => "object", "properties" => {} }],
+          "description" => "The description."
         }
         is_expected.to eq(schema)
       end

--- a/spec/lib/swagger_yard/model_spec.rb
+++ b/spec/lib/swagger_yard/model_spec.rb
@@ -56,5 +56,24 @@ RSpec.describe SwaggerYard::Model do
         ]
       )
     end
+
+    context 'and an external schema' do
+      let(:tags) { [yard_tag("@model MyModel"),
+                    yard_tag("@inherits schema#OtherModel")] }
+      let(:url)  { 'http://example.com/schemas/v1.0' }
+      before do
+        SwaggerYard.configure do |config|
+          config.external_schema schema: url
+        end
+      end
+
+      its(:to_h) do
+        schema = {
+          "allOf" => [{ "$ref" => "#{url}#/definitions/OtherModel" },
+                      { "type" => "object", "properties" => {} }]
+        }
+        is_expected.to eq(schema)
+      end
+    end
   end
 end

--- a/spec/lib/swagger_yard/model_spec.rb
+++ b/spec/lib/swagger_yard/model_spec.rb
@@ -28,6 +28,18 @@ RSpec.describe SwaggerYard::Model do
     its(:discriminator) { is_expected.to eq("myType") }
   end
 
+  context "with only @model" do
+    let(:content) { "@model" }
+
+    its(:id) { is_expected.to eq("MyModel") }
+
+    context "and a namespaced class name" do
+      let(:object) { yard_class('MyApp::MyModel', content) }
+
+      its(:id) { is_expected.to eq('MyApp_MyModel') }
+    end
+  end
+
   context "with a description" do
     let(:desc) {"This is my class. Not your class."}
     let(:content) do

--- a/spec/lib/swagger_yard/swagger_spec.rb
+++ b/spec/lib/swagger_yard/swagger_spec.rb
@@ -100,6 +100,8 @@ RSpec.describe SwaggerYard::Swagger do
     it { is_expected.to_not be_empty }
 
     its(["required"]) { is_expected.to eq(["id", "relatives"])}
+
+    its(["description"]) { is_expected.to eq("This is the Pet model.")}
   end
 
   context "#/tags" do

--- a/spec/lib/swagger_yard/swagger_spec.rb
+++ b/spec/lib/swagger_yard/swagger_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe SwaggerYard::Swagger do
   context "#/definitions" do
     subject(:definitions) { swagger["definitions"] }
 
-    its(:keys) { are_expected.to eq(["AnimalThing", "Pet", "Pets_Dog", "Possession", "Transport"]) }
+    its(:keys) { are_expected.to include("AnimalThing", "Pet", "Pets_Dog", "Possession", "Transport") }
 
     its(["AnimalThing", "properties"]) { are_expected.to include("id", "type", "possessions") }
 

--- a/spec/lib/swagger_yard/swagger_spec.rb
+++ b/spec/lib/swagger_yard/swagger_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe SwaggerYard::Swagger do
   context "#/definitions" do
     subject(:definitions) { swagger["definitions"] }
 
-    its(:keys) { are_expected.to eq(["AnimalThing", "Pet", "Possession", "Transport"]) }
+    its(:keys) { are_expected.to eq(["AnimalThing", "Pet", "Pets_Dog", "Possession", "Transport"]) }
 
     its(["AnimalThing", "properties"]) { are_expected.to include("id", "type", "possessions") }
 
@@ -103,6 +103,14 @@ RSpec.describe SwaggerYard::Swagger do
 
     its(["description"]) { is_expected.to eq("This is the Pet model.")}
   end
+
+  context "#/definitions/Pets_Dog" do
+    subject { swagger["definitions"]["Pets_Dog"] }
+
+    its(["allOf"]) { is_expected.to_not be_empty }
+    its(["description"]) { is_expected.to eq("A dog model.")}
+  end
+
 
   context "#/tags" do
     subject { swagger["tags"] }

--- a/spec/support/yard_helpers.rb
+++ b/spec/support/yard_helpers.rb
@@ -10,4 +10,10 @@ module YARDHelpers
     method.docstring = YARD::Docstring.new(content, method)
     method
   end
+
+  def yard_class(name, content)
+    klass = YARD::CodeObjects::ClassObject.new(nil, name)
+    klass.docstring = YARD::Docstring.new(content, klass)
+    klass
+  end
 end


### PR DESCRIPTION
- Populate the model description from the class docstring
- Allow model name to be omitted, using the class name as the model name
- Allow inherits to use an arbitrary type (thus allowing inheriting from external schema)