### PR TITLE
Handle both orders of parameter/property tags

### DIFF
--- a/lib/swagger_yard/parameter.rb
+++ b/lib/swagger_yard/parameter.rb
@@ -5,7 +5,7 @@ module SwaggerYard
     def self.from_yard_tag(tag, operation)
       name, options_string = tag.name.split(/[\(\)]/)
       description = tag.text
-      description = name if description.strip.empty?
+      description = name if description.nil? || description.strip.empty?
       type = Type.from_type_list(tag.types)
 
       options = {}

--- a/lib/swagger_yard/property.rb
+++ b/lib/swagger_yard/property.rb
@@ -27,7 +27,7 @@ module SwaggerYard
     def to_h
       @type.to_h.tap do |h|
         unless h['$ref']
-          h["description"] = description if description
+          h["description"] = description if description && !description.strip.empty?
           if @nullable
             h["x-nullable"] = true
             if h["type"]

--- a/spec/lib/swagger_yard/model_spec.rb
+++ b/spec/lib/swagger_yard/model_spec.rb
@@ -76,8 +76,7 @@ RSpec.describe SwaggerYard::Model do
             "type" => "object",
             "properties" => {
               "myOtherProperty" => {
-                "type"=>"string",
-                "description"=>""
+                "type"=>"string"
               }
             }
           }

--- a/spec/lib/swagger_yard/operation_spec.rb
+++ b/spec/lib/swagger_yard/operation_spec.rb
@@ -69,6 +69,15 @@ RSpec.describe SwaggerYard::Operation do
     its("parameters.last.description") { is_expected.to eq("name") }
   end
 
+  context "with a declared parameter that has no description (reversed name/type)" do
+    let(:tags) { [yard_tag("@path [GET] /hello"),
+                  yard_tag("@parameter [string] name")] }
+
+    its("parameters.count") { is_expected.to eq(1) }
+    its("parameters.last.name") { is_expected.to eq("name") }
+    its("parameters.last.description") { is_expected.to eq("name") }
+  end
+
   context "with multiple body parameters, ignores all but the first one" do
     include SilenceLogger
 

--- a/spec/lib/swagger_yard/property_spec.rb
+++ b/spec/lib/swagger_yard/property_spec.rb
@@ -86,4 +86,16 @@ describe SwaggerYard::Property do
     it { is_expected.to eq('$ref' => '#/definitions/Name') }
   end
 
+  context "with no description" do
+    let(:tag) { yard_tag '@property myProperty [string]' }
+
+    it { is_expected.to eq({'type' => 'string' }) }
+  end
+
+  context "with no description (reversed name/type)" do
+    let(:tag) { yard_tag '@property [string] myProperty' }
+
+    it { is_expected.to eq({'type' => 'string' }) }
+  end
+
 end


### PR DESCRIPTION
Test for same result whether ordering style is`[type] name` or `name [type]`.