### PR TITLE
Allow @property tags on model methods

### DIFF
--- a/lib/swagger_yard.rb
+++ b/lib/swagger_yard.rb
@@ -14,6 +14,7 @@ require "swagger_yard/model"
 require "swagger_yard/path_item"
 require "swagger_yard/swagger"
 require "swagger_yard/openapi"
+require "swagger_yard/handlers"
 
 module SwaggerYard
   class Error < StandardError; end

--- a/lib/swagger_yard/configuration.rb
+++ b/lib/swagger_yard/configuration.rb
@@ -28,5 +28,9 @@ module SwaggerYard
       end if mappings
       @external_schema
     end
+
+    def register_dsl_method(meth, options = {})
+      SwaggerYard::Handlers::DSLHandler.register_dsl_method(meth, options)
+    end
   end
 end

--- a/lib/swagger_yard/handlers.rb
+++ b/lib/swagger_yard/handlers.rb
@@ -1,0 +1,35 @@
+module SwaggerYard::Handlers
+  class DSLHandler < YARD::Handlers::Ruby::Base
+    include YARD::CodeObjects
+    namespace_only
+
+    def self.method_options
+      @method_options ||= {}
+    end
+
+    def self.reset
+      method_options.keys.each do |m|
+        handler = handlers.detect { |h| h.respond_to?(:name) && h.send(:name).to_s == m.to_s }
+        handlers.delete handler if handler
+      end
+      method_options.clear
+    end
+
+    def self.register_dsl_method(name, options = {})
+      return if self.method_options[name.to_s]
+      options[:args] ||= 0..-1
+      self.method_options[name.to_s] = options
+      handles method_call(name)
+    end
+
+    def process
+      options = self.class.method_options[caller_method]
+      return unless options
+      call_params[options[:args]].each do |method_name|
+        object = MethodObject.new(namespace, method_name, scope)
+        object.signature = "def #{method_name}"
+        register(object)
+      end
+    end
+  end
+end

--- a/lib/swagger_yard/model.rb
+++ b/lib/swagger_yard/model.rb
@@ -12,7 +12,9 @@ module SwaggerYard
         model.add_info(yard_object)
         model.parse_tags(yard_object.tags)
         yard_object.children.each do |child|
-          model.parse_tags(child.tags)
+          next unless child.is_a?(YARD::CodeObjects::MethodObject)
+          prop = Property.from_method(child)
+          model.properties << prop if prop
         end
       end
     end

--- a/lib/swagger_yard/model.rb
+++ b/lib/swagger_yard/model.rb
@@ -11,6 +11,9 @@ module SwaggerYard
       new.tap do |model|
         model.add_info(yard_object)
         model.parse_tags(yard_object.tags)
+        yard_object.children.each do |child|
+          model.parse_tags(child.tags)
+        end
       end
     end
 

--- a/lib/swagger_yard/property.rb
+++ b/lib/swagger_yard/property.rb
@@ -6,15 +6,40 @@ module SwaggerYard
     include Example
     attr_reader :name, :description, :required, :type, :nullable
 
+    NAME_OPTIONS_REGEXP = /[\(\)]/
+
+    def self.tag_name(tag)
+      if tag.object.is_a?(YARD::CodeObjects::MethodObject)
+        tag.object.name.to_s
+      else
+        tag = SwaggerYard.requires_name(tag)
+        return nil unless tag
+        tag.name.split(NAME_OPTIONS_REGEXP).first
+      end
+    end
+
     def self.from_tag(tag)
-      tag = SwaggerYard.requires_name_and_type(tag)
+      tag = SwaggerYard.requires_type(tag)
       return nil unless tag
 
-      name, options_string = tag.name.split(/[\(\)]/)
+      name = tag_name(tag)
+      return nil unless name
+
+      text = tag.text
+
+      if (options_src = (tag.name || '')) =~ NAME_OPTIONS_REGEXP
+        _, options_string = options_src.split(NAME_OPTIONS_REGEXP)
+      elsif tag.name && tag.object.is_a?(YARD::CodeObjects::MethodObject)
+        if text
+          text = tag.name + ' ' + text
+        else
+          text = tag.name
+        end
+      end
 
       options = options_string.to_s.split(',').map(&:strip)
 
-      new(name, tag.types, tag.text, options)
+      new(name, tag.types, text, options)
     end
 
     def initialize(name, types, description, options)

--- a/lib/swagger_yard/property.rb
+++ b/lib/swagger_yard/property.rb
@@ -18,6 +18,11 @@ module SwaggerYard
       end
     end
 
+    def self.from_method(yard_method)
+      tags = yard_method.tags
+      from_tag(tags.first) unless tags.empty?
+    end
+
     def self.from_tag(tag)
       tag = SwaggerYard.requires_type(tag)
       return nil unless tag

--- a/spec/fixtures/models/person.rb
+++ b/spec/fixtures/models/person.rb
@@ -1,0 +1,22 @@
+# @model Person
+# @property [Person] parent
+class Person
+  extend Forwardable
+
+  # @property [string] (required)
+  def_delegators :get_parent, :first_name, :last_name
+
+  # @property [Address] the person's address
+  def address
+  end
+
+  # @property [integer] (required) the person's age
+  attr_reader :age
+
+  def some_non_model_method
+  end
+
+  private
+  def get_parent
+  end
+end

--- a/spec/lib/swagger_yard/handlers_spec.rb
+++ b/spec/lib/swagger_yard/handlers_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe SwaggerYard::Handlers do
+  include_context 'person.rb model'
+  subject { model }
+
+  describe 'method properties with a DSL method registered' do
+    before do
+      SwaggerYard.configure do |config|
+        config.register_dsl_method :def_delegators, args: (1..-1)
+      end
+    end
+
+    its('properties') { is_expected.to include(a_property_named('first_name'),
+                                               a_property_named('last_name')) }
+
+    its('properties') { is_expected.to_not include(a_property_named('get_parent')) }
+
+    it 'hands requiredness to each DSL method' do
+      first_name = model.property('first_name')
+      expect(first_name).to be_required
+    end
+  end
+end

--- a/spec/lib/swagger_yard/model_spec.rb
+++ b/spec/lib/swagger_yard/model_spec.rb
@@ -83,11 +83,8 @@ RSpec.describe SwaggerYard::Model do
   end
 
   context 'with method properties' do
-    let(:objects) do
-      SwaggerYard.yard_class_objects_from_file((FIXTURE_PATH + 'models' + 'person.rb').to_s)
-    end
-
-    subject(:model) { SwaggerYard::Model.from_yard_object(objects.first) }
+    include_context 'person.rb model'
+    subject { model }
 
     its('properties') { is_expected.to include(a_property_named('address'),
                                                a_property_named('parent'),

--- a/spec/lib/swagger_yard/model_spec.rb
+++ b/spec/lib/swagger_yard/model_spec.rb
@@ -81,4 +81,34 @@ RSpec.describe SwaggerYard::Model do
       expect(prop.example).to eq("Nick")
     end
   end
+
+  context 'with method properties' do
+    let(:objects) do
+      SwaggerYard.yard_class_objects_from_file((FIXTURE_PATH + 'models' + 'person.rb').to_s)
+    end
+
+    subject(:model) { SwaggerYard::Model.from_yard_object(objects.first) }
+
+    its('properties') { is_expected.to include(a_property_named('address'),
+                                               a_property_named('parent'),
+                                               a_property_named('age')) }
+
+    its('properties') { is_expected.to_not include(a_property_named('some_non_model_method'),
+                                                   a_property_named('get_parent')) }
+
+    it 'captures the type' do
+      address = model.property('address')
+      expect(address.type.name).to eq('Address')
+    end
+
+    it 'captures the description' do
+      address = model.property('address')
+      expect(address.description).to eq("the person's address")
+    end
+
+    it 'captures requiredness' do
+      age = model.property('age')
+      expect(age).to be_required
+    end
+  end
 end

--- a/spec/lib/swagger_yard/property_spec.rb
+++ b/spec/lib/swagger_yard/property_spec.rb
@@ -119,4 +119,39 @@ describe SwaggerYard::Property, 'from_method' do
     its(:name) { is_expected.to eq('foo') }
     its('type.name') { is_expected.to eq('string') }
   end
+
+  context 'with a name' do
+    let(:content) { '@property [string] hello' }
+    its(:name) { is_expected.to eq('foo') }
+    its(:description) { is_expected.to eq('hello') }
+  end
+
+  context 'with options' do
+    let(:content) { '@property [string] (required)' }
+    its(:name) { is_expected.to eq('foo') }
+    its('type.name') { is_expected.to eq('string') }
+    its(:required) { is_expected.to be_truthy }
+  end
+
+  context 'with some other tag' do
+    let(:content) { '@return [IO] the IO object' }
+    it { is_expected.to be_nil }
+  end
+
+  context 'with a docstring and a property tag' do
+    let(:content) { ['The "foo" property', '@property [Foo]'].join("\n") }
+    its(:name) { is_expected.to eq('foo') }
+    its('type.name') { is_expected.to eq('Foo') }
+    its(:description) { is_expected.to eq('The "foo" property') }
+  end
+
+  context 'with an @example' do
+    let(:content) { ['@property [Foo]', '@example 1'].join("\n") }
+    its(:example) { is_expected.to eq(1) }
+  end
+
+  context 'with another @example' do
+    let(:content) { ['@property [Foo]', '@example', '  {"type": "Foo"}'].join("\n") }
+    its(:example) { is_expected.to eq('type' => 'Foo') }
+  end
 end

--- a/spec/lib/swagger_yard/property_spec.rb
+++ b/spec/lib/swagger_yard/property_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe SwaggerYard::Property do
+describe SwaggerYard::Property, 'from_tag' do
   subject(:property) { described_class.from_tag(tag) }
   subject { property.type.schema }
 
@@ -97,5 +97,26 @@ describe SwaggerYard::Property do
     include SilenceLogger
     let(:tag) { yard_tag '@property myProperty' }
     it { is_expected.to be_nil }
+  end
+end
+
+describe SwaggerYard::Property, 'from_method' do
+  let(:content) { '' }
+  let(:method) { yard_method('foo', content) }
+  subject(:property) { described_class.from_method(method) }
+
+  context 'with no content' do
+    it { is_expected.to be_nil }
+  end
+
+  context 'with no @property tag' do
+    let(:content) { 'Hello Foo' }
+    it { is_expected.to be_nil }
+  end
+
+  context 'with no name' do
+    let(:content) { '@property [string]' }
+    its(:name) { is_expected.to eq('foo') }
+    its('type.name') { is_expected.to eq('string') }
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,4 +33,9 @@ RSpec.configure do |config|
 
   config.include SaveConfig
   config.include YARDHelpers
+
+  config.after do
+    SwaggerYard::Handlers::DSLHandler.reset
+    YARD::Registry.clear
+  end
 end

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -1,6 +1,6 @@
 hash_like_named = proc do |name|
   match do |actual|
-    actual.respond_to?(:name) ? actual.name : actual['name']
+    name == (actual.respond_to?(:name) ? actual.name : actual['name'])
   end
 
   diffable
@@ -8,3 +8,4 @@ end
 
 RSpec::Matchers.define(:a_parameter_named, &hash_like_named)
 RSpec::Matchers.define(:a_tag_named, &hash_like_named)
+RSpec::Matchers.define(:a_property_named, &hash_like_named)

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -5,3 +5,11 @@ RSpec.shared_examples_for SwaggerYard::Swagger do
 
   its(["definitions"]) { are_expected.to_not be_empty }
 end
+
+RSpec.shared_context 'person.rb model' do
+  let(:objects) do
+    SwaggerYard.yard_class_objects_from_file((FIXTURE_PATH + 'models' + 'person.rb').to_s)
+  end
+
+  let(:model) { SwaggerYard::Model.from_yard_object(objects.first) }
+end


### PR DESCRIPTION
Previously, `@property` tags were only recognized in class comment blocks. Now, they can be added in comments above methods. Additionally, custom DSL methods for model attributes/properties can be registered and allowed to have comment blocks as well.