### PR TITLE
Bugfix: anchored match array or object

### DIFF
--- a/lib/swagger_yard/model.rb
+++ b/lib/swagger_yard/model.rb
@@ -41,8 +41,12 @@ module SwaggerYard
       properties.detect {|prop| prop.name == key }
     end
 
+    TAG_ORDER = %w(model inherits discriminator property example)
+
     def parse_tags(tags)
-      tags.each do |tag|
+      sorted_tags = tags.each_with_index.sort_by { |t,i|
+        [TAG_ORDER.index(t.tag_name), i] }.map(&:first)
+      sorted_tags.each do |tag|
         case tag.tag_name
         when "model"
           @has_model_tag = true
@@ -63,7 +67,7 @@ module SwaggerYard
             if (prop = property(tag.name))
               prop.example = tag.text
             else
-              SwaggerYard.log.warn("no property '#{tag.name}' defined yet to which to attach example: #{value.inspect}")
+              SwaggerYard.log.warn("no property '#{tag.name}' defined yet to which to attach example: #{tag.text.inspect}")
             end
           else
             self.example = tag.text

--- a/lib/swagger_yard/type_parser.rb
+++ b/lib/swagger_yard/type_parser.rb
@@ -58,9 +58,9 @@ module SwaggerYard
       rule(identifier: simple(:id)) do
         v = id.to_s
         case v
-        when /array/i
+        when /^array$/i
           { 'type' => 'array', 'items' => { 'type' => 'string' } }
-        when /object/i
+        when /^object$/i
           { 'type' => 'object' }
         when "float", "double"
           { 'type' => 'number', 'format' => v }

--- a/spec/lib/swagger_yard/type_parser_spec.rb
+++ b/spec/lib/swagger_yard/type_parser_spec.rb
@@ -67,6 +67,8 @@ RSpec.describe SwaggerYard::TypeParser do
 
     it { expect_parse_to 'prefix#Foo::Bar' => { external_identifier: { namespace: 'prefix', identifier: 'Foo::Bar' } } }
 
+    it { expect_parse_to 'AnObject' => { identifier: 'AnObject' } }
+
     it { expect_parse_to 'object' => { identifier: 'object' } }
 
     it { expect_parse_to 'array<string>' => { array: { identifier: 'string' } } }
@@ -156,6 +158,10 @@ RSpec.describe SwaggerYard::TypeParser do
     it { expect_json_schema 'regexp< a b c >' => { "type" => "string", "pattern" => " a b c " } }
 
     it { expect_json_schema 'Foo' => { "$ref" => "#/definitions/Foo" } }
+
+    it { expect_json_schema 'AnArray' => { "$ref" => "#/definitions/AnArray" } }
+
+    it { expect_json_schema 'AnObject' => { "$ref" => "#/definitions/AnObject" } }
 
     it { expect_json_schema 'Foo::Bar' => { "$ref" => "#/definitions/Foo_Bar" } }
 


### PR DESCRIPTION
Otherwise, identifiers like `MyObject` will match instead of being
treated like custom definitions.