### PR TITLE
YARD visibility property support

### DIFF
--- a/lib/swagger_yard/api_group.rb
+++ b/lib/swagger_yard/api_group.rb
@@ -49,6 +49,8 @@ module SwaggerYard
     end
 
     def add_yard_object(yard_object)
+      return self if yard_object.visibility == :private && !SwaggerYard.config.include_private
+
       case yard_object.type
       when :class # controller
         add_info(yard_object)

--- a/lib/swagger_yard/configuration.rb
+++ b/lib/swagger_yard/configuration.rb
@@ -6,6 +6,7 @@ module SwaggerYard
     attr_accessor :controller_path, :model_path
     attr_accessor :path_discovery_function
     attr_accessor :security_definitions
+    attr_accessor :include_private
 
     # openapi-compatible names
     alias openapi_version swagger_version
@@ -20,6 +21,7 @@ module SwaggerYard
       @description = "Configure description with SwaggerYard.config.description"
       @security_definitions = {}
       @external_schema = {}
+      @include_private = true
     end
 
     def external_schema(mappings = nil)

--- a/spec/fixtures/specification/fully_private_controller.rb
+++ b/spec/fixtures/specification/fully_private_controller.rb
@@ -1,0 +1,7 @@
+# @resource FullyPrivate
+# @visibility private
+class FullyPrivateController
+  # @path [GET] /fully_private
+  def index
+  end
+end

--- a/spec/fixtures/specification/semi_private_controller.rb
+++ b/spec/fixtures/specification/semi_private_controller.rb
@@ -1,0 +1,11 @@
+# @resource SemiPrivate
+class SemiPrivateController
+  # @path [GET] /semi_private_public
+  def index
+  end
+
+  # @path [GET] /semi_private
+  # @visibility private
+  def index_private
+  end
+end

--- a/spec/lib/swagger_yard/api_group_spec.rb
+++ b/spec/lib/swagger_yard/api_group_spec.rb
@@ -41,4 +41,41 @@ describe SwaggerYard::ApiGroup do
       end
     end
   end
+
+  describe 'visibility' do
+    let(:fixture_files) do
+      controllers_fixtures_path = "#{FIXTURE_PATH.to_s}/specification"
+      %w[hello_controller.rb goodbye_controller.rb fully_private_controller.rb semi_private_controller.rb].map { |f| "#{controllers_fixtures_path}/#{f}" }
+    end
+
+    let(:yard_objects) do
+      fixture_files.map { |f| SwaggerYard.yard_objects_from_file(f, :class) }.flatten
+    end
+
+    context 'include private' do
+      before { SwaggerYard.config.include_private = true }
+      it 'should add private resources if include_private is true' do
+        groups = []
+        expect(yard_objects.count).to eq 4
+        yard_objects.each { |o| groups << SwaggerYard::ApiGroup.new.add_yard_object(o) }
+        resources = groups.map { |g| g.resource }.keep_if { |r| !r.nil? }
+        paths = groups.map { |g| g.path_items.keys }.flatten.keep_if { |p| !p.nil? }
+        expect(resources).to contain_exactly(*%w[Bonjour Farewell FullyPrivate SemiPrivate])
+        expect(paths).to contain_exactly(*%w[/bonjour /goodbye /fully_private /semi_private_public /semi_private])
+      end
+    end
+
+    context 'exclude private' do
+      before { SwaggerYard.config.include_private = false }
+      it 'should ignore private resources if include_private is false' do
+        groups = []
+        expect(yard_objects.count).to eq 4
+        yard_objects.each { |o| groups << SwaggerYard::ApiGroup.new.add_yard_object(o) }
+        resources = groups.map { |g| g.resource }.keep_if { |r| !r.nil? }
+        paths = groups.map { |g| g.path_items.keys }.flatten.keep_if { |p| !p.nil? }
+        expect(resources).to contain_exactly(*%w[Bonjour Farewell SemiPrivate])
+        expect(paths).to contain_exactly(*%w[/bonjour /goodbye /semi_private_public])
+      end
+    end
+  end
 end


### PR DESCRIPTION
Sometimes you want to have your API endpoints properly documented but some endpoints should remain private for internal usage, this visibility property support adds that feature to swagger_yard