### PR TITLE
Migrate travis CI to GitHub Actions

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -1,0 +1,28 @@
+name: RSpec
+
+on: push
+
+jobs:
+  rspec:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - 2.5
+          - 2.6
+          - 2.7
+          - 3.0
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+
+      - name: Run tests
+        run: bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: ruby
-rvm:
-  - 2.3
-  - 2.4
-  - 2.5
-  - 2.6
-script: bundle exec rake
-cache: bundler

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SwaggerYard [![Build Status](https://travis-ci.org/livingsocial/swagger_yard.svg?branch=master)](https://travis-ci.org/livingsocial/swagger_yard) #
+# SwaggerYard [![Build Status](https://github.com/livingsocial/swagger_yard/actions/workflows/rspec.yml/badge.svg)](https://github.com/livingsocial/swagger_yard/actions/workflows/rspec.yml)
 
 SwaggerYard is a gem to convert custom YARD tags in comments into Swagger 2.0 or OpenAPI 3.0.0 specs.
 

--- a/swagger_yard.gemspec
+++ b/swagger_yard.gemspec
@@ -17,19 +17,17 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,public,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["test/**/*"]
 
+  s.required_ruby_version = Gem::Requirement.new('>= 2.5.0')
+
   s.add_runtime_dependency 'yard'
   s.add_runtime_dependency 'parslet'
 
-  # TODO: drop the constraint when we drop 1.9 support
-  s.add_development_dependency 'rake', '< 12'
+  s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rspec-its'
-  # TODO: drop the constraint when we drop 1.9 support
-  s.add_development_dependency 'apivore', '< 1.6'
-  # TODO: drop explicit nokogiri dependency when we drop 1.9 support
-  s.add_development_dependency 'nokogiri', '< 1.8'
-  # TODO: Drop this dependency when we drop 1.9 support
-  s.add_development_dependency 'addressable', "<= 2.4.0"
+  s.add_development_dependency 'apivore'
+  s.add_development_dependency 'nokogiri'
+  s.add_development_dependency 'addressable'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'mocha'
   s.add_development_dependency 'bourne'


### PR DESCRIPTION
This implicitly drops support for old ruby versions. I've also added the required ruby version (at least 2.5.0) to the gemspec.

You can see the resulting run in the source repo (https://github.com/StefSchenkelaars/swagger_yard/actions/runs/1380264574)