### PR TITLE
Reuse constants from application in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Types of things (parameters or responses of an operation, properties of a model)
 - Basic types (integer, boolean, string, object, number, date, time, date-time, uuid, etc.) should be lowercased.
 - An array of models or basic types is specified with `[array<...>]`.
 - An enum of allowed string values is specified with `[enum<one,two,three>]`.
+- An enum of allowed values that are defined in the application `[enum<{CURRENCIES}>]`.
 - An object definition can include the property definitions of its fields, and / or of an additional property for any remaining allowed fields. E.g., `[object<name: string, age: integer,  string >]`
 - Structured data like objects, arrays, pairs, etc., definitions can also be nested; E.g., `[object<pairs:array<object<right:integer,left:integer>>>]`
 - JSON-Schema `format` attributes can be specified for basic types using `<...>`. For example, `[integer<int64>]` produces JSON `{ "type": "integer", "format": "int64" }`.

--- a/lib/swagger_yard.rb
+++ b/lib/swagger_yard.rb
@@ -19,6 +19,7 @@ require "swagger_yard/directives"
 
 module SwaggerYard
   class Error < StandardError; end
+  class UnknownConstant < Error; end
   class InvalidTypeError < Error; end
   class UndefinedSchemaError < Error; end
 

--- a/spec/lib/swagger_yard/property_spec.rb
+++ b/spec/lib/swagger_yard/property_spec.rb
@@ -66,6 +66,32 @@ describe SwaggerYard::Property, 'from_tag' do
     its(['enum'])           { is_expected.to eq(['one', 'two', 'three']) }
   end
 
+  context 'with constant' do
+    before do
+      CURRENCIES = %w(usd eur)
+      module Constants
+        LANGUAGES = %w(en nl de)
+      end
+    end
+
+    after { Object.send(:remove_const, :CURRENCIES) }
+    after { Object.send(:remove_const, :Constants) }
+
+    context "with a constant enum" do
+      let(:tag) { yard_tag '@property currency [enum<isk,{CURRENCIES}>] Used currency' }
+
+      its(['type'])           { is_expected.to eq('string') }
+      its(['enum'])           { is_expected.to eq(%w[isk usd eur]) }
+    end
+
+    context "with a namespaced constant enum" do
+      let(:tag) { yard_tag '@property currency [enum<{Constants::LANGUAGES}, fr>] Used language' }
+
+      its(['type'])           { is_expected.to eq('string') }
+      its(['enum'])           { is_expected.to eq(%w[en nl de fr]) }
+    end
+  end
+
   context "with a required flag" do
     subject { property }
     let(:tag) { yard_tag '@property name(required) [string]  Name' }


### PR DESCRIPTION
I would like to be able to reuse definitions from the application in the API documentation without specifying them a second time. So to solve this i've made it possible to pass a constant that will be evaluated. 

```ruby
# @model
# @property currency [enum<{Product::CURRENCIES}>] The currency of the product
class Product
  CURRENCIES = %w[usd eur]
end

