### PR TITLE
Fix sort_by failing if a tag does not exist in TAG_ORDER

### DIFF
--- a/lib/swagger_yard/model.rb
+++ b/lib/swagger_yard/model.rb
@@ -46,7 +46,7 @@ module SwaggerYard
 
     def parse_tags(tags)
       sorted_tags = tags.each_with_index.sort_by { |t,i|
-        [TAG_ORDER.index(t.tag_name), i] }.map(&:first)
+        [TAG_ORDER.index(t.tag_name) || 0, i] }.map(&:first)
       sorted_tags.each do |tag|
         case tag.tag_name
         when "model"


### PR DESCRIPTION
Fixes an error if another tag is added to a model parsed by SwaggerYard eg. `YARD::Tags::Library.define_tag('MuCustomTag', :my_custom_tag)`

We have custom tags on our models that would cause warning messages when hit by [`::Yard.parse`](https://github.com/livingsocial/swagger_yard/blob/9d0c324b2c8918656e2d86dd23b68fb3377ea4ce/lib/swagger_yard.rb#L88). To suppress these warning messages, we define these custom tags in yard like so:

```ruby
YARD::Tags::Library.define_tag('Custom Tag', :custom_tag)
```

In doing so, however, it causes `spec = SwaggerYard::OpenAPI.new.to_h` to error out at the line changed in this PR since the custom tag does not exist in `TAG_ORDER`.

Since the case statement following the fixed line is a no-op on custom tags we can simply set the sort value of those tags to 0 to avoid `nil` comparisons and keep them in the `sorted_tags` array.

Command run (our custom rake task to generate OpenAPI docs):
`time bundle exec rails swagger_yard:generate --trace`

Error:
```
rails aborted!
ArgumentError: comparison of Array with Array failed
/Users/andrewszczepanski/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/swagger_yard-1.1.1/lib/swagger_yard/model.rb:48:in `sort_by'
/Users/andrewszczepanski/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/swagger_yard-1.1.1/lib/swagger_yard/model.rb:48:in `parse_tags'
/Users/andrewszczepanski/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/swagger_yard-1.1.1/lib/swagger_yard/model.rb:14:in `block in from_yard_object'
<internal:kernel>:90:in `tap'
/Users/andrewszczepanski/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/swagger_yard-1.1.1/lib/swagger_yard/model.rb:12:in `from_yard_object'
/Users/andrewszczepanski/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/swagger_yard-1.1.1/lib/swagger_yard/specification.rb:47:in `block (3 levels) in parse_models'
/Users/andrewszczepanski/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/swagger_yard-1.1.1/lib/swagger_yard/specification.rb:46:in `map'
/Users/andrewszczepanski/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/swagger_yard-1.1.1/lib/swagger_yard/specification.rb:46:in `block (2 levels) in parse_models'
/Users/andrewszczepanski/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/swagger_yard-1.1.1/lib/swagger_yard/specification.rb:45:in `map'
/Users/andrewszczepanski/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/swagger_yard-1.1.1/lib/swagger_yard/specification.rb:45:in `block in parse_models'
/Users/andrewszczepanski/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/swagger_yard-1.1.1/lib/swagger_yard/specification.rb:44:in `map'
/Users/andrewszczepanski/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/swagger_yard-1.1.1/lib/swagger_yard/specification.rb:44:in `parse_models'
/Users/andrewszczepanski/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/swagger_yard-1.1.1/lib/swagger_yard/specification.rb:36:in `models'
/Users/andrewszczepanski/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/swagger_yard-1.1.1/lib/swagger_yard/specification.rb:26:in `model_objects'
/Users/andrewszczepanski/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/swagger_yard-1.1.1/lib/swagger_yard/openapi.rb:29:in `components'
/Users/andrewszczepanski/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/swagger_yard-1.1.1/lib/swagger_yard/openapi.rb:23:in `definitions'
/Users/andrewszczepanski/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/swagger_yard-1.1.1/lib/swagger_yard/openapi.rb:4:in `to_h'
/Users/andrewszczepanski/code/platform-core/lib/tasks/swagger_yard.rake:13:in `block (2 levels) in <main>'
```

This duplicates https://github.com/livingsocial/swagger_yard/pull/81 because I needed to change the downstream branch.